### PR TITLE
#163519140 add reset password via email endpoint

### DIFF
--- a/__tests__/controllers/MailController.js
+++ b/__tests__/controllers/MailController.js
@@ -17,4 +17,18 @@ describe('sendgrid', () => {
     expect(res.length).toBeGreaterThan(0);
     expect(res[0].statusCode).toBe(202);
   }, 30000);
+
+  test('should send the Reset password link email', async () => {
+    expect.assertions(2);
+    const res = await MailController.resetPasswordEmail(db.mailUser);
+    expect(res).toBeDefined();
+    expect(res[0].statusCode).toBe(202);
+  }, 30000);
+
+  test('should send password changed email', async () => {
+    expect.assertions(2);
+    const res = await MailController.newPasswordEmail(db.mailUser);
+    expect(res).toBeDefined();
+    expect(res[0].statusCode).toBe(202);
+  }, 30000);
 });

--- a/__tests__/routes/user.test.js
+++ b/__tests__/routes/user.test.js
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '../../app';
 import { urlPrefix } from '../mocks/variables.json';
-import { User } from '../../database/models';
+import { User, ResetPassword } from '../../database/models';
 import { signupUser } from '../mocks/db.json';
 
 const fakeConfirmationCode = '07e83585-41e5-4fb2-b5d0-a7b52b55aba1';
@@ -50,5 +50,74 @@ describe('users', () => {
     );
     expect(res.status).toBe(401);
     expect(res.body.message).toBe('test@email.com has already been confirmed');
+  });
+
+  // Forget password tests
+  test('Password reset link sent sucessfully', async () => {
+    const res = await request(app)
+      .post(`${urlPrefix}/users/forget`)
+      .send({ user: { email: 'test@email.com' } });
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe('Password reset link sent sucessfully. Please check your email!');
+  }, 30000);
+
+  test('No user found with that email address', async () => {
+    const res = await request(app)
+      .post(`${urlPrefix}/users/forget`)
+      .send({ user: { email: 'fake@email.com' } });
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('No user found with that email address');
+  });
+  test('Bad request- password forget', async () => {
+    const res = await request(app)
+      .post(`${urlPrefix}/users/forget`)
+      .send({ user: { emailx: 'fake@email.com' } });
+    expect(res.status).toBe(400);
+  });
+
+  test('No user found with that email address- Unconfirmed email', async () => {
+    await user.update({ confirmed: 'pending' });
+    const res = await request(app)
+      .post(`${urlPrefix}/users/forget`)
+      .send({ user: { email: 'test@email.com' } });
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('No user found with that email address');
+  });
+
+  // Reset password tests
+  test('Reset password- fail', async () => {
+    const reset = await ResetPassword.findOne({ where: { userId: user.id } });
+    const res = await request(app)
+      .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
+      .send({ newPassword: 'mugiha', confirmNewpassword: 'mugisha' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe("Passwords don't match");
+  });
+
+  test('Reset password- Bad request', async () => {
+    const reset = await ResetPassword.findOne({ where: { userId: user.id } });
+    const res = await request(app)
+      .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
+      .send({ newPassword: 'mugisha', confirmpassword: 'mugisha' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Bad Request');
+  });
+
+  test('Reset password- invalid token', async () => {
+    const reset = await ResetPassword.findOne({ where: { userId: user.id } });
+    const res = await request(app)
+      .put(`${urlPrefix}/users/${reset.userId}/reset/7ced290d-f51a-472c-8086-7e8161fc40b9`)
+      .send({ newPassword: 'mugisha', confirmNewpassword: 'mugisha' });
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('invalid token');
+  }, 30000);
+
+  test('Reset password- success', async () => {
+    const reset = await ResetPassword.findOne({ where: { userId: user.id } });
+    const res = await request(app)
+      .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
+      .send({ newPassword: 'mugisha', confirmNewpassword: 'mugisha' });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Your password has been reset successfully!');
   });
 });

--- a/__tests__/routes/user.test.js
+++ b/__tests__/routes/user.test.js
@@ -14,6 +14,11 @@ describe('users', () => {
     });
     user = await User.create({ ...signupUser });
   });
+
+  afterAll(async () => {
+    await ResetPassword.destroy({ where: { userId: user.id } });
+  });
+
   test('should return invalid confirmation code -fake userid and confirmationCode', async () => {
     expect.assertions(2);
     const res = await request(app).get(
@@ -52,8 +57,8 @@ describe('users', () => {
     expect(res.body.message).toBe('test@email.com has already been confirmed');
   });
 
-  // Forget password tests
   test('Password reset link sent sucessfully', async () => {
+    expect.assertions(2);
     const res = await request(app)
       .post(`${urlPrefix}/users/forget`)
       .send({ user: { email: 'test@email.com' } });
@@ -62,6 +67,7 @@ describe('users', () => {
   }, 30000);
 
   test('No user found with that email address', async () => {
+    expect.assertions(2);
     const res = await request(app)
       .post(`${urlPrefix}/users/forget`)
       .send({ user: { email: 'fake@email.com' } });
@@ -69,6 +75,7 @@ describe('users', () => {
     expect(res.body.message).toBe('No user found with that email address');
   });
   test('Bad request- password forget', async () => {
+    expect.assertions(1);
     const res = await request(app)
       .post(`${urlPrefix}/users/forget`)
       .send({ user: { emailx: 'fake@email.com' } });
@@ -76,6 +83,7 @@ describe('users', () => {
   });
 
   test('No user found with that email address- Unconfirmed email', async () => {
+    expect.assertions(2);
     await user.update({ confirmed: 'pending' });
     const res = await request(app)
       .post(`${urlPrefix}/users/forget`)
@@ -84,8 +92,8 @@ describe('users', () => {
     expect(res.body.message).toBe('No user found with that email address');
   });
 
-  // Reset password tests
   test('Reset password- fail', async () => {
+    expect.assertions(2);
     const reset = await ResetPassword.findOne({ where: { userId: user.id } });
     const res = await request(app)
       .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
@@ -95,6 +103,7 @@ describe('users', () => {
   });
 
   test('Reset password- Bad request', async () => {
+    expect.assertions(2);
     const reset = await ResetPassword.findOne({ where: { userId: user.id } });
     const res = await request(app)
       .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
@@ -104,6 +113,7 @@ describe('users', () => {
   });
 
   test('Reset password- invalid token', async () => {
+    expect.assertions(2);
     const reset = await ResetPassword.findOne({ where: { userId: user.id } });
     const res = await request(app)
       .put(`${urlPrefix}/users/${reset.userId}/reset/7ced290d-f51a-472c-8086-7e8161fc40b9`)
@@ -113,11 +123,22 @@ describe('users', () => {
   }, 30000);
 
   test('Reset password- success', async () => {
+    expect.assertions(2);
     const reset = await ResetPassword.findOne({ where: { userId: user.id } });
     const res = await request(app)
       .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
       .send({ newPassword: 'mugisha', confirmNewpassword: 'mugisha' });
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Your password has been reset successfully!');
-  });
+  }, 30000);
+
+  test('Reset password- success', async () => {
+    expect.assertions(2);
+    const reset = await ResetPassword.findOne({ where: { userId: user.id } });
+    const res = await request(app)
+      .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
+      .send({ newPassword: 'mugisha', confirmNewpassword: 'mugisha' });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Your password has been reset successfully!');
+  }, 30000);
 });

--- a/__tests__/routes/user.test.js
+++ b/__tests__/routes/user.test.js
@@ -74,12 +74,23 @@ describe('users', () => {
     expect(res.status).toBe(404);
     expect(res.body.message).toBe('No user found with that email address');
   });
+
   test('Bad request- password forget', async () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const res = await request(app)
       .post(`${urlPrefix}/users/forget`)
       .send({ user: { emailx: 'fake@email.com' } });
     expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Bad Request');
+  });
+
+  test('Bad request- password forget', async () => {
+    expect.assertions(2);
+    const res = await request(app)
+      .post(`${urlPrefix}/users/forget`)
+      .send({ user: { emailx: 'fake' } });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Bad Request');
   });
 
   test('No user found with that email address- Unconfirmed email', async () => {
@@ -112,6 +123,16 @@ describe('users', () => {
     expect(res.body.message).toBe('Bad Request');
   });
 
+  test('Reset password- Bad request', async () => {
+    expect.assertions(2);
+    const reset = await ResetPassword.findOne({ where: { userId: user.id } });
+    const res = await request(app)
+      .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
+      .send({ newPassword: 'mug', confirmpassword: 'mug' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Bad Request');
+  });
+
   test('Reset password- invalid token', async () => {
     expect.assertions(2);
     const reset = await ResetPassword.findOne({ where: { userId: user.id } });
@@ -120,17 +141,7 @@ describe('users', () => {
       .send({ newPassword: 'mugisha', confirmNewpassword: 'mugisha' });
     expect(res.status).toBe(404);
     expect(res.body.message).toBe('invalid token');
-  }, 30000);
-
-  test('Reset password- success', async () => {
-    expect.assertions(2);
-    const reset = await ResetPassword.findOne({ where: { userId: user.id } });
-    const res = await request(app)
-      .put(`${urlPrefix}/users/${reset.userId}/reset/${reset.resetCode}`)
-      .send({ newPassword: 'mugisha', confirmNewpassword: 'mugisha' });
-    expect(res.status).toBe(200);
-    expect(res.body.message).toBe('Your password has been reset successfully!');
-  }, 30000);
+  });
 
   test('Reset password- success', async () => {
     expect.assertions(2);

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -107,8 +107,7 @@ class AuthController {
       await resetPasswordEmail(id, email, resetCode);
       res.status(201).json({
         status: 201,
-        message: 'Password reset link sent sucessfully. Please check your email!',
-        ResetPassword: createReset
+        message: 'Password reset link sent sucessfully. Please check your email!'
       });
     } catch (error) {
       return res.status(520).json({ message: 'Please try again' });
@@ -158,7 +157,6 @@ class AuthController {
           await newPasswordEmail(user.email);
           res.status(200).json({
             status: 200,
-            user: { ...user.get() },
             message: 'Your password has been reset successfully!'
           });
         }

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -111,7 +111,7 @@ class AuthController {
         ResetPassword: createReset
       });
     } catch (error) {
-      return res.status(401).json({ message: 'Please try again' });
+      return res.status(520).json({ message: 'Please try again' });
     }
   }
 
@@ -164,7 +164,7 @@ class AuthController {
         }
       }
     } catch (error) {
-      return res.status(401);
+      return res.status(520);
     }
   }
 }

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -3,8 +3,8 @@ import jwt from 'jsonwebtoken';
 import 'dotenv/config';
 import { Op } from 'sequelize';
 import bcrypt from 'bcrypt';
-import { User } from '../database/models';
-import { sendEmailConfirmationLink } from './MailController';
+import { User, ResetPassword } from '../database/models';
+import { sendEmailConfirmationLink, resetPasswordEmail, newPasswordEmail } from './MailController';
 
 const { JWT_SECRET } = process.env;
 
@@ -77,6 +77,95 @@ class AuthController {
         return next(error);
       }
     })(req, res, next);
+  }
+
+  /**
+   * @author Caleb
+   * @param {Object} req
+   * @param {Object} res
+   * @param {*} next
+   * @returns {Object} Returns the response
+   */
+  static async forgotPassword(req, res) {
+    const {
+      body: { user }
+    } = req;
+
+    try {
+      const reset = await User.findOne({
+        where: { email: user.email, confirmed: 'confirmed' },
+        attributes: ['id', 'email']
+      });
+      if (!reset) {
+        return res
+          .status(404)
+          .json({ status: 404, message: 'No user found with that email address' });
+      }
+      const { id, email } = reset.get();
+      const createReset = await ResetPassword.create({ userId: id });
+      const { resetCode } = createReset.get();
+      await resetPasswordEmail(id, email, resetCode);
+      res.status(201).json({
+        status: 201,
+        message: 'Password reset link sent sucessfully. Please check your email!',
+        ResetPassword: createReset
+      });
+    } catch (error) {
+      return res.status(401).json({ message: 'Please try again' });
+    }
+  }
+
+  /**
+   * @author Caleb
+   * @param {Object} req
+   * @param {Object} res
+   * @param {*} next
+   * @returns {Object} Returns the response
+   */
+  static async resetPassword(req, res) {
+    const { resetCode, userId } = req.params;
+    const { body } = req;
+    try {
+      const reset = await ResetPassword.findOne({
+        where: { resetCode, userId }
+      });
+
+      if (body.newPassword !== body.confirmNewpassword) {
+        res.status(400).json({ status: 400, message: "Passwords don't match" });
+      }
+      if (!reset) {
+        res.status(404).json({ status: 404, message: 'invalid token' });
+      }
+
+      if (body.newPassword === body.confirmNewpassword) {
+        const expirationTime = reset.createdAt.setMinutes(reset.createdAt.getMinutes() + 30);
+        const presentTime = new Date();
+
+        if (expirationTime < presentTime) {
+          res
+            .status(401)
+            .json({ status: 401, message: 'Expired token, Please request a new Token' });
+        }
+
+        if (expirationTime > presentTime) {
+          const user = await User.findOne({
+            where: { id: userId },
+            attributes: ['id', 'email']
+          });
+
+          const password = await bcrypt.hash(body.newPassword, 10);
+          await user.update({ password });
+          await newPasswordEmail(user.email);
+          res.status(200).json({
+            status: 200,
+            user: { ...user.get() },
+            message: 'Your password has been reset successfully!'
+          });
+        }
+      }
+    } catch (error) {
+      return res.status(401);
+    }
   }
 }
 export default AuthController;

--- a/controllers/MailController.js
+++ b/controllers/MailController.js
@@ -49,3 +49,44 @@ export const sendEmailVerified = (user = {}) => {
   `;
   return sendgrid({ to: user.email, subject: 'Email Confirmed', html: mailBody });
 };
+
+export const resetPasswordEmail = (userId, email, resetCode) => {
+  const mailBody = `
+  <div style="color: #5a5a5a;">
+      <div style="border-bottom: 1px solid #2ABDEB; padding: 15px;">
+        <h2 style="color: #2ABDEB; text-align: center;">Authors Haven - Reset your account password</h2>
+      </div>
+      <p style="font-size: 1.2rem; line-height: 2rem; color: #5a5a5a;">
+      To reset your password, click the link below.
+      <p/>
+      <div style="text-align: center; padding: 20px;">
+        <a href="${FRONTEND_URL}/users/${userId}/reset/${resetCode}"
+          style="color: #fff; background-color: #2ABDEB; padding: 10px 20px; font-size: 1.2rem; text-align: center; text-decoration: none;"
+        > Password reset </a>
+        <p style="font-size: 1.5rem; margin-top: 30px; color: #5a5a5a !important">
+          Or copy the link below
+        <p><br>${FRONTEND_URL}/users/${userId}/reset/${resetCode}
+      </div>
+      <p style="color: #5a5a5a !important;">If you didn't ask for password reset, Please ignore this message.</p>
+      <p style="color: #5a5a5a !important;">Thank you, <br> Authors Haven Team</p>
+    </div>
+  `;
+  return sendgrid({ to: email, subject: 'Password Reset', html: mailBody });
+};
+
+export const newPasswordEmail = email => {
+  const mailBody = `
+  <div style="color: #5a5a5a;">
+      <div style="border-bottom: 1px solid #2ABDEB; padding: 15px;">
+        <h2 style="color: #2ABDEB; text-align: center;">Authors Haven - Password changed</h2>
+      </div>
+      <div style="text-align: center; padding: 20px;">
+      <p style="font-size: 1.5rem; margin-top: 30px; color: #5a5a5a !important">
+      Your password has been reset successfully!</p>
+    </div>
+    <p style="color: #5a5a5a !important;">Thank you, <br> Authors Haven Team</p>
+  </div>
+      `;
+
+  return sendgrid({ to: email, subject: 'Password changed', html: mailBody });
+};

--- a/controllers/MailController.js
+++ b/controllers/MailController.js
@@ -62,7 +62,7 @@ export const resetPasswordEmail = (userId, email, resetCode) => {
       <div style="text-align: center; padding: 20px;">
         <a href="${FRONTEND_URL}/users/${userId}/reset/${resetCode}"
           style="color: #fff; background-color: #2ABDEB; padding: 10px 20px; font-size: 1.2rem; text-align: center; text-decoration: none;"
-        > Password reset </a>
+        > Password Reset </a>
         <p style="font-size: 1.5rem; margin-top: 30px; color: #5a5a5a !important">
           Or copy the link below
         <p><br>${FRONTEND_URL}/users/${userId}/reset/${resetCode}
@@ -88,5 +88,5 @@ export const newPasswordEmail = email => {
   </div>
       `;
 
-  return sendgrid({ to: email, subject: 'Password changed', html: mailBody });
+  return sendgrid({ to: email, subject: 'Password Changed', html: mailBody });
 };

--- a/database/migrations/20190213154608-create-reset-password.js
+++ b/database/migrations/20190213154608-create-reset-password.js
@@ -1,0 +1,30 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('ResetPasswords', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4
+      },
+      userId: {
+        type: Sequelize.UUID
+      },
+      resetCode: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('ResetPasswords');
+  }
+};

--- a/database/models/resetpassword.js
+++ b/database/models/resetpassword.js
@@ -1,0 +1,33 @@
+module.exports = (sequelize, DataTypes) => {
+  const ResetPassword = sequelize.define(
+    'ResetPassword',
+    {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4
+      },
+      userId: {
+        type: DataTypes.UUID
+      },
+      resetCode: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      }
+    },
+    {}
+  );
+  ResetPassword.associate = function(models) {
+    ResetPassword.belongsTo(models.User, { foreignKey: 'userId' });
+  };
+  return ResetPassword;
+};

--- a/database/models/user.js
+++ b/database/models/user.js
@@ -69,7 +69,7 @@ module.exports = (sequelize, DataTypes) => {
     {}
   );
   User.associate = function(models) {
-    // Association
+    User.hasMany(models.ResetPassword, { foreignKey: 'userId' });
   };
   return User;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3809,7 +3809,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3830,12 +3831,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3850,17 +3853,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3977,7 +3983,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3989,6 +3996,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4003,6 +4011,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4010,12 +4019,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4034,6 +4045,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4114,7 +4126,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4126,6 +4139,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4211,7 +4225,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4247,6 +4262,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4266,6 +4282,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4309,12 +4326,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -21,5 +21,19 @@ router.post(
 );
 
 router.get('/:userId/confirm_email/:confirmationCode', UserController.confirmEmail);
+router.post(
+  '/forget',
+  celebrate({
+    body: authValidator.forgetPassword
+  }),
+  AuthController.forgotPassword
+);
+router.put(
+  '/:userId/reset/:resetCode',
+  celebrate({
+    body: authValidator.resetPassword
+  }),
+  AuthController.resetPassword
+);
 
 export default router;

--- a/routes/validators/auth.js
+++ b/routes/validators/auth.js
@@ -28,7 +28,29 @@ const login = {
   })
 };
 
+const forgetPassword = {
+  user: Joi.object().keys({
+    email: Joi.string()
+      .email()
+      .required()
+      .trim()
+  })
+};
+
+const resetPassword = {
+  newPassword: Joi.string()
+    .required()
+    .min(6)
+    .max(60),
+  confirmNewpassword: Joi.string()
+    .required()
+    .min(6)
+    .max(60)
+};
+
 export default {
   signup,
-  login
+  login,
+  forgetPassword,
+  resetPassword
 };


### PR DESCRIPTION

#### What does this PR do?
adds reset the password via email endpoint

#### Description of Task to be completed?
- forget password endpoint
- send reset password email to a user
- reset password endpoint
- send a confirmation email to a user
- unit tests

#### How should this be manually tested?
- git clone this branch

- run `npm install`

- run `npm migrate:seed`

- run `npm run dev`

- with postman use this link to signup:
`POST: api/v1/users/forget`

- Body request example (forget email):
```request-json
{
   "email":"test@mail.com"
}
```
- After you check email with reset password link and copy it or click it
-Go back to postman with PUT method copy the link in URL
`PUT: api/v1/users//:userId/reset/:resetCode`

- Body request example (reset password):
```request-json
{
   "newPassword":"password",
    "confirmNewPassword":"password"
}
```


#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
`#163519140`

#### Screenshots (if appropriate)
- Reset password email
![image](https://user-images.githubusercontent.com/29614532/52786763-7a67da00-3064-11e9-930a-6407a1c1ed66.png)

- Reset password confirmation email
![image](https://user-images.githubusercontent.com/29614532/52786858-aedb9600-3064-11e9-9d1a-c19d13026b6b.png)

#### Questions:
N/A
