### PR TITLE
#164492386 Implement remove authentication when sharing an article

### DIFF
--- a/__tests__/mocks/db.json
+++ b/__tests__/mocks/db.json
@@ -121,6 +121,6 @@
     "body": "Quis culpa ad exercitation sunt pariatur ut commodo ipsum ipsum. Labore velit laborum cupidatat laborum excepteur. Lorem eu do cupidatat amet eiusmod veniam.",
     "description": "exercitation",
     "status": "published",
-    "tagList": ["share", "social"]
+    "tagList": ["share"]
   }
 }

--- a/__tests__/routes/share.test.js
+++ b/__tests__/routes/share.test.js
@@ -58,7 +58,7 @@ describe('articles', () => {
         ]
       }
     }).then(() => true);
-    await Article.destroy({ where: { tagList: { [Op.contains]: ['share', 'social'] } } });
+    await Article.destroy({ where: { tagList: { [Op.contains]: ['share'] } } });
   });
 
   test('should return created article', async () => {

--- a/__tests__/routes/share.test.js
+++ b/__tests__/routes/share.test.js
@@ -76,7 +76,9 @@ describe('articles', () => {
 
   test('should share article on twitter', async () => {
     expect.assertions(3);
-    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/twitter`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/twitter`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
@@ -84,7 +86,9 @@ describe('articles', () => {
 
   test('should fail to share article on twitter', async () => {
     expect.assertions(4);
-    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/twitter`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${fakeSlug}/share/twitter`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBe('Article not found');
@@ -93,7 +97,9 @@ describe('articles', () => {
 
   test('should share article on Facebook', async () => {
     expect.assertions(3);
-    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/facebook`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/facebook`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
@@ -101,7 +107,9 @@ describe('articles', () => {
 
   test('should fail to share article on Facebook', async () => {
     expect.assertions(4);
-    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/facebook`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${fakeSlug}/share/facebook`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBe('Article not found');
@@ -110,7 +118,9 @@ describe('articles', () => {
 
   test('should share article on Linkedin', async () => {
     expect.assertions(3);
-    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/linkedin`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/linkedin`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
@@ -118,7 +128,9 @@ describe('articles', () => {
 
   test('should fail to share article on Linkedin', async () => {
     expect.assertions(4);
-    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/linkedin`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${fakeSlug}/share/linkedin`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBe('Article not found');
@@ -127,7 +139,9 @@ describe('articles', () => {
 
   test('should share article on email', async () => {
     expect.assertions(3);
-    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/email`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/email`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
@@ -135,7 +149,9 @@ describe('articles', () => {
 
   test('should fail to share article on email', async () => {
     expect.assertions(4);
-    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/email`);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${fakeSlug}/share/email`)
+      .set('Authorization', loginUser1.token);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBe('Article not found');

--- a/__tests__/routes/share.test.js
+++ b/__tests__/routes/share.test.js
@@ -75,6 +75,7 @@ describe('articles', () => {
   });
 
   test('should share article on twitter', async () => {
+    expect.assertions(3);
     const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/twitter`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
@@ -82,13 +83,16 @@ describe('articles', () => {
   });
 
   test('should fail to share article on twitter', async () => {
+    expect.assertions(4);
     const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/twitter`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
+    expect(res.body.message).toBe('Article not found');
     expect(res.body.message).toBeDefined();
   });
 
   test('should share article on Facebook', async () => {
+    expect.assertions(3);
     const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/facebook`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
@@ -96,13 +100,16 @@ describe('articles', () => {
   });
 
   test('should fail to share article on Facebook', async () => {
+    expect.assertions(4);
     const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/facebook`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
+    expect(res.body.message).toBe('Article not found');
     expect(res.body.message).toBeDefined();
   });
 
   test('should share article on Linkedin', async () => {
+    expect.assertions(3);
     const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/linkedin`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
@@ -110,13 +117,16 @@ describe('articles', () => {
   });
 
   test('should fail to share article on Linkedin', async () => {
+    expect.assertions(4);
     const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/linkedin`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
+    expect(res.body.message).toBe('Article not found');
     expect(res.body.message).toBeDefined();
   });
 
   test('should share article on email', async () => {
+    expect.assertions(3);
     const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/email`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
@@ -124,9 +134,11 @@ describe('articles', () => {
   });
 
   test('should fail to share article on email', async () => {
+    expect.assertions(4);
     const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/email`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
+    expect(res.body.message).toBe('Article not found');
     expect(res.body.message).toBeDefined();
   });
 });

--- a/__tests__/routes/share.test.js
+++ b/__tests__/routes/share.test.js
@@ -58,7 +58,7 @@ describe('articles', () => {
         ]
       }
     }).then(() => true);
-    await Article.destroy({ where: { tagList: { [Op.contains]: ['test'] } } });
+    await Article.destroy({ where: { tagList: { [Op.contains]: ['share', 'social'] } } });
   });
 
   test('should return created article', async () => {
@@ -75,72 +75,56 @@ describe('articles', () => {
   });
 
   test('should share article on twitter', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/twitter`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/twitter`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
   });
 
   test('should fail to share article on twitter', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${fakeSlug}/share/twitter`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/twitter`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBeDefined();
   });
 
   test('should share article on Facebook', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/facebook`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/facebook`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
   });
 
   test('should fail to share article on Facebook', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${fakeSlug}/share/facebook`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/facebook`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBeDefined();
   });
 
   test('should share article on Linkedin', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/linkedin`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/linkedin`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
   });
 
   test('should fail to share article on Linkedin', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${fakeSlug}/share/linkedin`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/linkedin`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBeDefined();
   });
 
   test('should share article on email', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${newArticle2.slug}/share/email`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${newArticle2.slug}/share/email`);
     expect(res.status).toBe(200);
     expect(res.body.status).toBe(200);
     expect(res.body.message).toBeDefined();
   });
 
   test('should fail to share article on email', async () => {
-    const res = await request(app)
-      .get(`${urlPrefix}/articles/${fakeSlug}/share/email`)
-      .set('Authorization', loginUser1.token);
+    const res = await request(app).get(`${urlPrefix}/articles/${fakeSlug}/share/email`);
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBeDefined();

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -25,7 +25,11 @@ router.get(
   asyncHandler(ArticleController.searchArticles)
 );
 
-router.get('/:slug', verifyJwt({ tokenRequired: false }), asyncHandler(ArticleController.getArticle));
+router.get(
+  '/:slug',
+  verifyJwt({ tokenRequired: false }),
+  asyncHandler(ArticleController.getArticle)
+);
 router.put(
   '/:slug',
   celebrate({ body: articleValidator.createArticle }),
@@ -55,10 +59,12 @@ router.get(
   verifyJwt(),
   asyncHandler(CommentController.getArticleComments)
 );
-router.route('/:articleSlug/rating')
+router
+  .route('/:articleSlug/rating')
   .post(
     celebrate({ body: ratingValidator }),
-    verifyJwt(), asyncHandler(RatingController.rateArticle)
+    verifyJwt(),
+    asyncHandler(RatingController.rateArticle)
   )
   .delete(verifyJwt(), asyncHandler(RatingController.deleteRating))
   .get(asyncHandler(RatingController.getAllRating));
@@ -67,29 +73,19 @@ router.post('/:slug/like', verifyJwt(), asyncHandler(ArticleController.likeArtic
 
 router.post('/:slug/dislike', verifyJwt(), asyncHandler(ArticleController.dislikeArticle));
 
-router.get(
-  '/:slug/share/twitter',
-  verifyJwt({ tokenRequired: false }),
-  asyncHandler(ArticleController.shareArticleTwitter)
-);
+router.get('/:slug/share/twitter', asyncHandler(ArticleController.shareArticleTwitter));
 
-router.get(
-  '/:slug/share/facebook',
-  verifyJwt(),
-  asyncHandler(ArticleController.shareArticleFacebook)
-);
+router.get('/:slug/share/facebook', asyncHandler(ArticleController.shareArticleFacebook));
 
-router.get(
-  '/:slug/share/linkedin',
-  verifyJwt(),
-  asyncHandler(ArticleController.shareArticleLinkedin)
-);
+router.get('/:slug/share/linkedin', asyncHandler(ArticleController.shareArticleLinkedin));
 
 router.get('/:slug/share/email', verifyJwt(), asyncHandler(ArticleController.shareArticleEmail));
-router.route('/:articleSlug/rating')
+router
+  .route('/:articleSlug/rating')
   .post(
     celebrate({ body: ratingValidator }),
-    verifyJwt(), asyncHandler(RatingController.rateArticle)
+    verifyJwt(),
+    asyncHandler(RatingController.rateArticle)
   )
   .delete(verifyJwt(), asyncHandler(RatingController.deleteRating))
   .get(asyncHandler(RatingController.getAllRating));

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -73,11 +73,23 @@ router.post('/:slug/like', verifyJwt(), asyncHandler(ArticleController.likeArtic
 
 router.post('/:slug/dislike', verifyJwt(), asyncHandler(ArticleController.dislikeArticle));
 
-router.get('/:slug/share/twitter', asyncHandler(ArticleController.shareArticleTwitter));
+router.get(
+  '/:slug/share/twitter',
+  verifyJwt({ tokenRequired: false }),
+  asyncHandler(ArticleController.shareArticleTwitter)
+);
 
-router.get('/:slug/share/facebook', asyncHandler(ArticleController.shareArticleFacebook));
+router.get(
+  '/:slug/share/facebook',
+  verifyJwt({ tokenRequired: false }),
+  asyncHandler(ArticleController.shareArticleFacebook)
+);
 
-router.get('/:slug/share/linkedin', asyncHandler(ArticleController.shareArticleLinkedin));
+router.get(
+  '/:slug/share/linkedin',
+  verifyJwt({ tokenRequired: false }),
+  asyncHandler(ArticleController.shareArticleLinkedin)
+);
 
 router.get('/:slug/share/email', verifyJwt(), asyncHandler(ArticleController.shareArticleEmail));
 router

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -91,7 +91,11 @@ router.get(
   asyncHandler(ArticleController.shareArticleLinkedin)
 );
 
-router.get('/:slug/share/email', verifyJwt(), asyncHandler(ArticleController.shareArticleEmail));
+router.get(
+  '/:slug/share/email',
+  verifyJwt({ tokenRequired: false }),
+  asyncHandler(ArticleController.shareArticleEmail)
+);
 router
   .route('/:articleSlug/rating')
   .post(


### PR DESCRIPTION
#### What does this PR do?
Implement remove authentication when sharing an article

#### Description of Task to be completed?

- remove authentication in social sharing routers
- remove authentication in social sharing unit tests

#### How should this be manually tested?
- run `npm install`

- run `npm run migrate:seed`

- run `npm run test`

- To share via email with postman navigate to 
`POST: api/v1/articles/:slug/share/email`

- To share via Facebook with postman navigate to 
`POST: api/v1/articles/:slug/share/Facebook`

- To share via Twitter with postman navigate to 
`POST: api/v1/articles/:slug/share/twitter`

- To share via Linkedin with postman navigate to 
`POST: api/v1/articles/:slug/share/Linkedin`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#164492386

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
