### PR TITLE
#163519163 Add track comment history functionality

### DIFF
--- a/__tests__/routes/comment.test.js
+++ b/__tests__/routes/comment.test.js
@@ -178,6 +178,16 @@ describe('comments', () => {
     done();
   });
 
+  test('Comment history - This comment was not edited', async done => {
+    const res = await request(app)
+      .get(`${urlPrefix}/comments/${newComment.id}/edited`)
+      .set('Authorization', loginUser1.token);
+    expect(res.status).toBe(404);
+    expect(res.body.status).toBe(404);
+    expect(res.body.message).toBeDefined();
+    done();
+  });
+
   /* Update a comment test cases */
 
   test('UPDATE - should return Bad Request', async done => {
@@ -234,6 +244,42 @@ describe('comments', () => {
     expect(res.status).toBe(404);
     expect(res.body.status).toBe(404);
     expect(res.body.message).toBe('Comment not found');
+    done();
+  });
+
+  test('UPDATE - should return updated comment', async done => {
+    const commentBody = 'New body';
+    expect.assertions(4);
+    const res = await request(app)
+      .put(`${urlPrefix}/comments/${newComment.id}`)
+      .set('Authorization', loginUser1.token)
+      .send({ comment: { body: commentBody } });
+    newComment = res.body.comment;
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe(200);
+    expect(res.body.comment.id).toBeDefined();
+    expect(res.body.comment.body).toBe(commentBody);
+    done();
+  });
+
+  test('Comment history - should return old version', async done => {
+    const res = await request(app)
+      .get(`${urlPrefix}/comments/${newComment.id}/edited`)
+      .set('Authorization', loginUser1.token);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe(200);
+    expect(res.body.editedComment.id).toBeDefined();
+    expect(res.body.editedComment).toBeDefined();
+    done();
+  });
+
+  test('Comment history - should fail to return old version', async done => {
+    const res = await request(app)
+      .get(`${urlPrefix}/comments/0ded7537-c7c2-4d4c-84d8-e941c84e965f/edited`)
+      .set('Authorization', loginUser1.token);
+    expect(res.status).toBe(404);
+    expect(res.body.status).toBe(404);
+    expect(res.body.message).toBeDefined();
     done();
   });
 

--- a/__tests__/routes/comment.test.js
+++ b/__tests__/routes/comment.test.js
@@ -273,6 +273,17 @@ describe('comments', () => {
     done();
   });
 
+  test('Comment history - should fail to return old version- wrong token', async done => {
+    const res = await request(app)
+      .get(`${urlPrefix}/comments/${newComment.id}/edited`)
+      .set('Authorization', loginUser2.token);
+    expect(res.status).toBe(401);
+    expect(res.body.status).toBe(401);
+    expect(res.body.status).toBe(401);
+    expect(res.body.message).toBeDefined();
+    done();
+  });
+
   test('Comment history - should fail to return old version', async done => {
     const res = await request(app)
       .get(`${urlPrefix}/comments/0ded7537-c7c2-4d4c-84d8-e941c84e965f/edited`)

--- a/__tests__/routes/notification.test.js
+++ b/__tests__/routes/notification.test.js
@@ -197,11 +197,11 @@ describe('articles', () => {
     const res = await request(app)
       .get(`${urlPrefix}/notifications`)
       .set('Authorization', loginUser2.token);
-    notificationId = res.body.notification.rows[0].id;
+    notificationId = res.body.notifications[0].id;
     expect(res.status).toBe(200);
-    expect(res.body.notification).toBeDefined();
+    expect(res.body.notifications).toBeDefined();
     expect(res.body.status).toBe(200);
-    expect(res.body.notification.count).toBeDefined();
+    expect(res.body.notificationsCount).toBeDefined();
   });
 
   test('get one notification', async () => {

--- a/controllers/CommentController.js
+++ b/controllers/CommentController.js
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import moment from 'moment';
-import { Comment, User, Article } from '../database/models';
+import { Comment, User, Article, OldComment } from '../database/models';
 import newInteractionNotification from '../helpers/notification/newInteractionNotification';
 
 /**
@@ -95,8 +95,20 @@ class CommentController {
       return res.status(401).json({ status: 401, message: 'Unauthorized access' });
     }
 
+    const oldcomment = await OldComment.findOne({ where: { commentId } });
+
+    if (oldcomment) {
+      await oldcomment.destroy();
+    }
+
+    await OldComment.create({
+      commentId: foundComment.id,
+      body: foundComment.body,
+      userId: currentUser.id
+    });
     await foundComment.update({
       body: comment.body,
+      version: 'edited',
       updateAt: moment().format()
     });
 
@@ -179,6 +191,43 @@ class CommentController {
       status: 200,
       message: 'Comment deleted successfully'
     });
+  }
+
+  /**
+   * @author Caleb
+   * @param {Object} req
+   * @param {Object} res
+   * @param {*} next
+   * @returns {Object} Returns the response
+   */
+  static async ViewCommentEdit(req, res) {
+    const { commentId } = req.params;
+    const foundComment = await Comment.findOne({
+      where: { id: commentId }
+    });
+
+    if (!foundComment) {
+      return res.status(404).json({
+        status: 404,
+        message: 'Comment not found'
+      });
+    }
+
+    if (foundComment.version !== 'edited') {
+      return res.status(404).json({ status: 404, message: 'This comment was not edited' });
+    }
+    const commentHistory = await OldComment.findOne({
+      where: { commentId },
+      include: [
+        {
+          model: User,
+          as: 'author',
+          attributes: ['username', 'firstName', 'lastName', 'image']
+        }
+      ]
+    });
+
+    return res.status(200).json({ status: 200, editedComment: commentHistory });
   }
 }
 

--- a/controllers/NotificationController.js
+++ b/controllers/NotificationController.js
@@ -32,15 +32,14 @@ class NotificationController {
         .status(404)
         .json({ status: 404, message: "You don't have any unread notification" });
     }
-    if (notifications) {
-      return res.status(200).json({
-        status: 200,
-        notifications: notifications.rows,
-        notificationsCount: notifications.count,
-        pages: Math.ceil(notifications.count / limit),
-        page
-      });
-    }
+
+    return res.status(200).json({
+      status: 200,
+      notifications: notifications.rows,
+      notificationsCount: notifications.count,
+      pages: Math.ceil(notifications.count / limit),
+      page
+    });
   }
 
   /**

--- a/controllers/NotificationController.js
+++ b/controllers/NotificationController.js
@@ -33,7 +33,13 @@ class NotificationController {
         .json({ status: 404, message: "You don't have any unread notification" });
     }
     if (notifications) {
-      return res.status(200).json({ status: 200, notification: notifications });
+      return res.status(200).json({
+        status: 200,
+        notifications: notifications.rows,
+        notificationsCount: notifications.count,
+        pages: Math.ceil(notifications.count / limit),
+        page
+      });
     }
   }
 

--- a/database/migrations/20190226092709-create-comment.js
+++ b/database/migrations/20190226092709-create-comment.js
@@ -1,4 +1,3 @@
-'use strict';
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('Comments', {
@@ -20,6 +19,11 @@ module.exports = {
       },
       body: {
         type: Sequelize.STRING,
+        allowNull: false
+      },
+      version: {
+        type: Sequelize.STRING,
+        defaultValue: 'original',
         allowNull: false
       },
       createdAt: {

--- a/database/models/comment.js
+++ b/database/models/comment.js
@@ -18,6 +18,11 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false
     },
+    version: {
+      type: DataTypes.STRING,
+      defaultValue: 'original',
+      allowNull: false
+    },
     createdAt: {
       allowNull: false,
       type: DataTypes.DATE
@@ -31,7 +36,7 @@ module.exports = (sequelize, DataTypes) => {
     Comment.belongsTo(models.User, { foreignKey: 'userId', as: 'author' });
     Comment.belongsTo(models.Article, { foreignKey: 'articleId' });
     Comment.hasMany(models.Comment, { foreignKey: 'parentId', as: 'replies' });
-    Comment.hasMany(models.FavoriteComment, { foreignKey: 'id', as: 'likes' })
+    Comment.hasMany(models.FavoriteComment, { foreignKey: 'id', as: 'likes' });
   };
   return Comment;
 };

--- a/helpers/notification/newFollowerNotification.js
+++ b/helpers/notification/newFollowerNotification.js
@@ -11,14 +11,12 @@ export default async (followee, follower) => {
   const followerObject = await User.findByPk(follower);
   const followeeObject = await User.findOne({ where: { id: followee, notification: 'enabled' } });
 
-  if (followeeObject) {
-    notificationObject.push({
-      userId: followeeObject.id,
-      notification: `${followerObject.username} started following you`,
-      link: `${FRONTEND_URL}/users/userId`
-    });
+  notificationObject.push({
+    userId: followeeObject.id,
+    notification: `${followerObject.username} started following you`,
+    link: `${FRONTEND_URL}/users/userId`
+  });
 
-    await inAppNotification(notificationObject);
-    await newFollowerEmail(followeeObject.email, followerObject.username);
-  }
+  await inAppNotification(notificationObject);
+  await newFollowerEmail(followeeObject.email, followerObject.username);
 };

--- a/routes/api/comments.js
+++ b/routes/api/comments.js
@@ -16,4 +16,6 @@ router.put(
 
 router.delete('/:commentId', verifyJwt(), asyncHandler(CommentController.deleteComment));
 
+router.get('/:commentId/edited', verifyJwt(), asyncHandler(CommentController.ViewCommentEdit));
+
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Add track comment history functionality

#### Description of Task to be completed?
- add tests
- create comment history model and migration
- add comment history functionality
- add comment history route

#### How should this be manually tested?
On this branch
- Run `npm run migrate:seed`

- Run `npm run test`

- Run `npm run dev`

With postman send post requests to these endpoints:
- To check the previous version of a comment `GET: api/v1/comments/:commentId/edited`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#163519163

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A