### PR TITLE
#165595089 Implemented viewing likes and dislikes 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgres://username:password@localhost:5432/db_name
+DATABASE_URL=postgres://username:password@localhost:5432/dbname
 JWT_SECRET=secret
 SENDGRID_API_KEY=
 FRONTEND_URL=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgres://username:password@localhost:5432/dbname
+DATABASE_URL=postgres://username:password@localhost:5432/db_name
 JWT_SECRET=secret
 SENDGRID_API_KEY=
 FRONTEND_URL=http://localhost:3000

--- a/__tests__/routes/article.test.js
+++ b/__tests__/routes/article.test.js
@@ -289,6 +289,22 @@ describe('articles', () => {
     expect(res.body.article).toBeDefined();
   });
 
+  test('Article - should get likes', async () => {
+    expect.assertions(2);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${newArticle.slug}/likes`)
+      .set('Authorization', loginUser2.token);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBeDefined();
+  });
+
+  test('Article - should get likes', async () => {
+    expect.assertions(2);
+    const res = await request(app).get(`${urlPrefix}/articles/${newArticle.slug}/likes`);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBeDefined();
+  });
+
   test('dislike a liked article', async () => {
     expect.assertions(3);
     const res = await request(app)
@@ -297,6 +313,22 @@ describe('articles', () => {
     expect(res.status).toBe(200);
     expect(res.body.article).toBeDefined();
     expect(res.body.message).toBe('Disliked');
+  });
+
+  test('Article - should get dislikes', async () => {
+    expect.assertions(2);
+    const res = await request(app)
+      .get(`${urlPrefix}/articles/${newArticle.slug}/dislikes`)
+      .set('Authorization', loginUser2.token);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBeDefined();
+  });
+
+  test('Article - should get dislikes', async () => {
+    expect.assertions(2);
+    const res = await request(app).get(`${urlPrefix}/articles/${newArticle.slug}/dislikes`);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBeDefined();
   });
 
   test('Remove dislike from an article', async () => {

--- a/__tests__/routes/profile.test.js
+++ b/__tests__/routes/profile.test.js
@@ -73,7 +73,7 @@ describe('Profile', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.user.firstName).toBe('Peter');
-    expect(res.body.message).toBe('The information was updated successful');
+    expect(res.body.message).toBe('The information was updated successfully');
     done();
   });
 
@@ -136,7 +136,7 @@ describe('Profile', () => {
       .set('Authorization', loginUser1.token)
       .send({ user: { username: 'claudine' } });
     expect(res.status).toBe(200);
-    expect(res.body.message).toBe('The information was updated successful');
+    expect(res.body.message).toBe('The information was updated successfully');
     done();
   });
 

--- a/app.js
+++ b/app.js
@@ -35,8 +35,8 @@ app.use(
     secret: 'MYSECRETISVERYSECRET',
     store,
     resave: true,
-    saveUninitialized: true,
-  }),
+    saveUninitialized: true
+  })
 );
 app.use(passport.initialize());
 app.use(passport.session());
@@ -66,8 +66,8 @@ app.use((err, req, res) => {
   res.status(err.status || 500).json({
     errors: {
       message: err.message,
-      error: err,
-    },
+      error: err
+    }
   });
 });
 

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -734,7 +734,8 @@ class ArticleController {
         model: User,
         as: 'author',
         attributes: ['firstName', 'lastName', 'image']
-      }
+      },
+      order: [['updatedAt', 'DESC']]
     });
 
     if (currentUser) {
@@ -773,7 +774,8 @@ class ArticleController {
         model: User,
         as: 'author',
         attributes: ['firstName', 'lastName', 'image']
-      }
+      },
+      order: [['updatedAt', 'DESC']]
     });
 
     if (currentUser) {

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import opn from 'opn';
+import open from 'open';
 import sequelize, { Op } from 'sequelize';
 import { User, Article, Favorite, Follow, Tag, Report, Bookmark, Reader } from '../database/models';
 import { slugString, getReadingTime, calculateRating } from '../helpers';
@@ -413,7 +413,7 @@ class ArticleController {
         message: 'Article not found'
       });
     }
-    opn(`https://twitter.com/intent/tweet?text=${process.env.FRONTEND_URL}/articles/${slug}`);
+    open(`https://twitter.com/intent/tweet?text=${process.env.FRONTEND_URL}/articles/${slug}`);
     return res.status(200).json({ status: 200, message: 'Sharing article via Twitter' });
   }
 
@@ -438,7 +438,7 @@ class ArticleController {
         message: 'Article not found'
       });
     }
-    opn(
+    open(
       `https://www.facebook.com/sharer/sharer.php?&u=https://lit-kigali1-staging.herokuapp.com/api/v1/article/${slug}`
     );
     return res.status(200).json({ status: 200, message: 'Sharing article via Facebook' });
@@ -465,7 +465,7 @@ class ArticleController {
         message: 'Article not found'
       });
     }
-    opn(
+    open(
       `https://www.linkedin.com/sharing/share-offsite/?url=${
         process.env.FRONTEND_URL
       }/articles/${slug}`
@@ -494,7 +494,7 @@ class ArticleController {
         message: 'Article not found'
       });
     }
-    opn(`mailto:?subject=${article.title}&body=${process.env.FRONTEND_URL}/article/${slug}`);
+    open(`mailto:?subject=${article.title}&body=${process.env.FRONTEND_URL}/article/${slug}`);
     return res.status(200).json({ status: 200, message: 'Sharing article via Email' });
   }
 

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -729,7 +729,7 @@ class ArticleController {
 
     const likes = await Favorite.findAndCountAll({
       where: { articleId: article.id, state: 'like' },
-      attributes: ['state', 'createdAt'],
+      attributes: ['state', 'updatedAt'],
       include: {
         model: User,
         as: 'author',
@@ -768,7 +768,7 @@ class ArticleController {
 
     const dislikes = await Favorite.findAndCountAll({
       where: { articleId: article.id, state: 'dislike' },
-      attributes: ['state', 'createdAt'],
+      attributes: ['state', 'updatedAt'],
       include: {
         model: User,
         as: 'author',
@@ -786,7 +786,7 @@ class ArticleController {
     res.status(200).json({
       status: 200,
       count: dislikes.count,
-      likes: dislikes.rows,
+      dislikes: dislikes.rows,
       disliked
     });
   }

--- a/controllers/ArticleController.js
+++ b/controllers/ArticleController.js
@@ -18,9 +18,8 @@ class ArticleController {
    * @returns {Object} Returns the response
    */
   static async createArticle(req, res) {
-    const { file, currentUser } = req;
+    const { currentUser } = req;
     const { article } = req.body;
-    const cover = file ? file.url : undefined;
     const slug = slugString(article.title);
     const readingTime = getReadingTime(article.body);
     const newArticle = await Article.create(
@@ -28,7 +27,6 @@ class ArticleController {
         ...article,
         userId: currentUser.id,
         slug,
-        cover,
         readingTime
       },
       {

--- a/controllers/AuthController.js
+++ b/controllers/AuthController.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { User, ResetPassword, Token } from '../database/models';
 import { sendEmailConfirmationLink, resetPasswordEmail, newPasswordEmail } from './MailController';
 
-const { JWT_SECRET } = process.env;
+const { JWT_SECRET, FRONTEND_URL } = process.env;
 
 /**
  * @description Authentication class
@@ -192,7 +192,7 @@ class AuthController {
    * @returns {Object} Returns the response
    */
   static async socialLogin(req, res) {
-    return res.json({ status: 200, user: req.user });
+    res.redirect(`${FRONTEND_URL}?token=${req.user.token}`);
   }
 }
 

--- a/controllers/ProfileController.js
+++ b/controllers/ProfileController.js
@@ -198,12 +198,15 @@ class ProfileController {
    */
   static async getCurrentUser(req, res) {
     const { currentUser } = req;
-
+    const articles = await Article.findAll({
+      where: { userId: currentUser.id, status: { [Op.not]: 'deleted' } }
+    });
     return res.status(200).json({
       status: 200,
       user: {
         ...currentUser,
-        password: undefined
+        password: undefined,
+        articles
       }
     });
   }

--- a/controllers/ProfileController.js
+++ b/controllers/ProfileController.js
@@ -61,11 +61,11 @@ class ProfileController {
       await sendEmailConfirmationLink({ ...profile.get() });
       message = 'Your email has changed. Please check your email for confirmation';
     } else {
-      message = 'The information was updated successful';
+      message = 'The information was updated successfully';
     }
     const { confirmationCode, ...userData } = profile.get();
     return res.status(200).send({
-      statu: 200,
+      status: 200,
       message,
       user: userData
     });

--- a/controllers/RatingController.js
+++ b/controllers/RatingController.js
@@ -28,6 +28,7 @@ class RatingController {
     if (rating) {
       await rating.update({ rating: rate, updatedAt: new Date() });
       const averageRate = await calculateRating(articleId);
+
       return res.status(200).send({
         status: 200,
         message: 'Rating updated successfully',
@@ -35,7 +36,6 @@ class RatingController {
         averageRate
       });
     }
-    const averageRate = await calculateRating(articleId);
     const newRate = await Favorite.create(
       {
         userId: currentUser.id,
@@ -44,6 +44,8 @@ class RatingController {
       },
       { include: [{ model: User, as: 'author' }, { model: Article, as: 'favorites' }] }
     );
+    const averageRate = await calculateRating(articleId);
+
     return res.status(201).send({
       status: 201,
       message: 'article has been rated successfully',
@@ -105,6 +107,9 @@ class RatingController {
         articleId: article.id,
         rating: { [Op.ne]: null }
       },
+      include: [
+        { model: User, as: 'author', attributes: ['username', 'firstName', 'lastName', 'image'] }
+      ],
       limit,
       offset: (queryPage - 1) * limit
     });
@@ -116,6 +121,7 @@ class RatingController {
     }
     return res.status(200).send({
       status: 200,
+      article: article.get(),
       averageRate: await calculateRating(null, article.slug),
       ratings: allRating.rows,
       page: Number(queryPage),

--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -31,7 +31,7 @@ class UserController {
     await user.update({ confirmed: 'confirmed', confirmationCode: null });
 
     await sendEmailVerified(user.get());
-    return res.json({ message: `${user.email} has been confirmed` });
+    return res.status(200).json({ status: 200, message: `${user.email} has been confirmed` });
   }
 
   /**

--- a/database/mocks/articles.js
+++ b/database/mocks/articles.js
@@ -79,5 +79,260 @@ module.exports = [
     tagList,
     createdAt,
     updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '6e7325d7-c8be-43eb-b1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-6',
+    title: 'new article 6',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '7e7325d7-c8be-43eb-b1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-7',
+    title: 'new article 7',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '8e7325d7-c8be-43eb-b1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-8',
+    title: 'new article 8',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '9e7325d7-c8be-43eb-b1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-9',
+    title: 'new article 9',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '1e7325d7-c8be-43eb-b1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-10',
+    title: 'new article 10',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '3e7325d7-c8be-43eb-b1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-11',
+    title: 'new article 11',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1060',
+    id: 'b9a4731d-7dea-4a9a-9b7d-8766d651c202',
+    userId: 'dfef16f9-11a7-4eae-9ba0-7038c6ccaa73',
+    slug: 'new-article-12',
+    title: 'new article onex',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1051',
+    id: '919cbf82-5290-4b34-be59-18e94ccb4afc',
+    userId: '4b134316-966b-47f8-bb47-2fb27a36b40c',
+    slug: 'new-article-137',
+    title: 'new article 137',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1071',
+    id: '7bfe144e-936d-47ae-817c-55e001dcb28f',
+    userId: '09a0a74f-e2d0-4976-84bc-8118b0c3d86c',
+    slug: 'new-article-135',
+    title: 'new article 133',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1071',
+    id: 'ad54bed9-c3ca-6300-a2ce-7dbbeae07b69',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-14',
+    title: 'new article 14',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList: ['dump'],
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '2e7325d7-f8be-43eb-b1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-15',
+    title: 'new article 15',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '6e7325d7-c8be-43eb-e1e4-5bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-16',
+    title: 'new article 16',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '7e7325d7-c8be-43eb-b1e4-8bba07b65914',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-17',
+    title: 'new article 17',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '7e7325d7-c8be-43eb-b1e4-8bba07b65921',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-19',
+    title: 'new article 19',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '7e7325d7-c8be-43eb-b1e4-8bba07b15924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-20',
+    title: 'new article 20',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '7e7325d7-c8be-43eb-b1e4-1bba07b65924',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-21',
+    title: 'new article 21',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
+  },
+  {
+    cover: 'https://picsum.photos/500/300?image=1043',
+    id: '7e7325d7-c8be-43eb-b1e4-8bba07b65926',
+    userId: 'd018c3b5-13c7-41c0-8b2c-4ec1cb6b21da',
+    slug: 'new-article-22',
+    title: 'new article 22',
+    description: 'new article',
+    body:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus ipsum non metus finibus ultricies. Donec ac auctor dui, sed fringilla est. Duis et pellentesque nisl, a gravida felis. Ut tempor felis id dignissim congue. Nunc blandit nunc sit amet dui pharetra, quis porttitor sem ullamcorper. Suspendisse faucibus imperdiet lacinia.',
+    status: 'published',
+    readingTime: '1 min',
+    tagList,
+    createdAt,
+    updatedAt
   }
 ];

--- a/middlewares/passportStrategies.js
+++ b/middlewares/passportStrategies.js
@@ -102,12 +102,12 @@ passport.use(
       try {
         const data = profile._json;
         const user = await User.findOrCreate({
-          where: { username: profile.id },
+          where: { username: data.screen_name },
           defaults: {
-            username: data.id,
+            username: data.screen_name,
             email: `${data.username}@twitter.com`,
             firstName: data.screen_name,
-            password: data.id,
+            password: data.screen_name,
             socialId: data.id,
             socialEmail: data.email || null,
             authType: 'twitter',
@@ -170,12 +170,12 @@ passport.use(
       try {
         const data = profile._json;
         const user = await User.findOrCreate({
-          where: { socialId: profile.id },
+          where: { username: data.name.givenName },
           defaults: {
-            username: data.id,
+            username: data.name.givenName,
             email: data.id,
-            firstName: data.displayName,
-            password: profile.id,
+            firstName: data.name.givenName,
+            password: data.name.givenName,
             socialId: profile.id,
             socialEmail: data.email || null,
             authType: 'Gmail',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "nock": "^10.0.6",
     "node-sass": "^4.11.0",
     "nodemon": "^1.18.9",
+    "open": "^6.1.0",
     "opn": "^5.4.0",
     "passport": "^0.4.0",
     "passport-facebook": "^3.0.0",

--- a/routes/api/articles.js
+++ b/routes/api/articles.js
@@ -41,10 +41,7 @@ router.get(
   asyncHandler(ArticleController.getArticleReports)
 );
 
-router.get('/feed',
-verifyJwt({ tokenRequired: true }),
-asyncHandler(ArticleController.getFeed)
-);
+router.get('/feed', verifyJwt({ tokenRequired: true }), asyncHandler(ArticleController.getFeed));
 
 router.get(
   '/:slug',
@@ -156,12 +153,18 @@ router.put(
   asyncHandler(CommentController.updateComment)
 );
 
-router.delete('/:articleSlug/comments/:commentId', verifyJwt(), asyncHandler(CommentController.deleteComment));
-router.get('/:articleSlug/comments/:commentId/edited', verifyJwt(), asyncHandler(CommentController.ViewCommentEdit));
+router.delete(
+  '/:articleSlug/comments/:commentId',
+  verifyJwt(),
+  asyncHandler(CommentController.deleteComment)
+);
+router.get(
+  '/:articleSlug/comments/:commentId/edited',
+  verifyJwt(),
+  asyncHandler(CommentController.ViewCommentEdit)
+);
 
-router.get('/feed',
-verifyJwt({ tokenRequired: true }),
-asyncHandler(ArticleController.getFeed));
+router.get('/feed', verifyJwt({ tokenRequired: true }), asyncHandler(ArticleController.getFeed));
 
 router.post(
   '/:articleSlug/comment-on-text',
@@ -175,6 +178,18 @@ router.put(
   celebrate({ body: commentValidator.updateHighlightedTextComment }),
   verifyJwt(),
   asyncHandler(CommentOnTextController.updateComment)
+);
+
+router.get(
+  '/:slug/likes',
+  verifyJwt({ tokenRequired: false }),
+  asyncHandler(ArticleController.getLikes)
+);
+
+router.get(
+  '/:slug/dislikes',
+  verifyJwt({ tokenRequired: false }),
+  asyncHandler(ArticleController.getDislikes)
 );
 
 export default router;

--- a/routes/validators/article.js
+++ b/routes/validators/article.js
@@ -17,10 +17,10 @@ const createArticle = {
         .items(Joi.string().trim()),
       status: Joi.string()
         .trim()
-        .valid(['unpublished', 'published'])
+        .valid(['unpublished', 'published']),
+      cover: Joi.string(),
     })
     .required(),
-  cover: Joi.any()
 };
 
 const getArticlesQuery = {

--- a/routes/validators/user.js
+++ b/routes/validators/user.js
@@ -8,7 +8,7 @@ const profile = {
     email: Joi.string()
       .email()
       .trim(),
-    bio: Joi.string().min(20),
+    bio: Joi.string(),
     gender: Joi.string().max(6),
     birthDate: Joi.date(),
     image: Joi.string(),


### PR DESCRIPTION
#### What does this PR do?
Add functionality for viewing people who liked and disliked an article

#### Description of Task to be completed?
This PR has the following end-points working

- `GET: api/v1/articles/:slug/likes`

- `GET: api/v1/articles/:slug/dislikes`


#### How should this be manually tested?

- clone this repo

- run `npm install`

- run `npm run migrate:seed`

- run `npm run test`

#### Any background context you want to provide?
No authentication required for these API end-points

#### What are the relevant pivotal tracker stories?
#165595089

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A